### PR TITLE
feat: reconvert streamline dashboards on templates file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ If the templates file doesn't exist, expansion is silently skipped — the app w
 
 Template properties with `_javascript` suffixes (e.g. `service_javascript`, `icon_color_javascript`) are kept in the YAML output with `[[variable]]` placeholders substituted, but they require the Streamline runtime to execute. They appear in the YAML for readability.
 
+### Automatic reconversion on template changes
+
+When you edit `streamline_templates.yaml` manually, any dashboards using Streamline cards will be stale until the next UI save. To fix this automatically, enable HA's built-in `folder_watcher` integration to watch the templates file:
+
+```yaml
+folder_watcher:
+  - folder: /config/www/community/streamline-card
+    patterns:
+      - "streamline_templates.yaml"
+```
+
+Add this to `configuration.yaml` and restart HA. After that, editing `streamline_templates.yaml` will automatically trigger reconversion of all dashboards that reference Streamline cards — dashboards without Streamline cards are unaffected.
+
 ## Limitations
 
 - Only works with dashboards in **storage mode**. Dashboards configured via YAML files in `/config/` are not affected.

--- a/pyscript/apps/lovelace_to_yaml/__init__.py
+++ b/pyscript/apps/lovelace_to_yaml/__init__.py
@@ -5,6 +5,7 @@ See https://github.com/maxlyth/homeassistant-lovelace-to-yaml for documentation.
 
 import importlib.util as _ilu
 import logging as _logging
+import os
 
 _cfg = pyscript.app_config or {}
 CONFIG_DIR = _cfg.get("config_dir", "/config")
@@ -29,6 +30,7 @@ _spec.loader.exec_module(lovelace_core)
 _LOGGER = _logging.getLogger("custom_components.pyscript.apps.lovelace_to_yaml")
 
 EVENT_LOVELACE_UPDATED = "lovelace_updated"
+EVENT_FOLDER_WATCHER = "folder_watcher"
 
 
 # ── Core conversion ───────────────────────────────────────────────────────────
@@ -47,12 +49,41 @@ def _do_convert(url):
         _LOGGER.error("lovelace_to_yaml: conversion failed: %s", result.error)
 
 
+@pyscript_executor
+def _reconvert_streamline_dashboards():
+    storage_dir = os.path.join(CONFIG_DIR, ".storage")
+    urls = lovelace_core.list_dashboard_urls(storage_dir)
+    converted = 0
+    for url in urls:
+        if not lovelace_core.dashboard_uses_streamline(url, storage_dir):
+            continue
+        result = lovelace_core.convert_dashboard(url, CONFIG_DIR, OUTPUT_DIR, streamline_templates_path=STREAMLINE_TEMPLATES_PATH)
+        if result.success:
+            _LOGGER.info("lovelace_to_yaml: reconverted '%s' → %s", result.dashboard_id, result.output_path)
+            converted += 1
+        else:
+            _LOGGER.error("lovelace_to_yaml: reconversion failed for '%s': %s", url, result.error)
+    _LOGGER.info("lovelace_to_yaml: streamline reconvert complete (%d dashboards)", converted)
+
+
 # ── Triggers ──────────────────────────────────────────────────────────────────
 
 @event_trigger(EVENT_LOVELACE_UPDATED)
 def lovelace_updated_event(url_path=None):
     log.info(f"lovelace_to_yaml: lovelace_updated event (url_path={url_path!r})")
     _do_convert(url_path)
+
+
+@event_trigger(EVENT_FOLDER_WATCHER)
+def streamline_templates_changed(**kwargs):
+    path = kwargs.get("path", "")
+    event_type = kwargs.get("event_type", "")
+    if not path.endswith("streamline_templates.yaml"):
+        return
+    if event_type not in ("modified", "created", "closed"):
+        return
+    log.info(f"lovelace_to_yaml: streamline_templates.yaml changed ({event_type}), reconverting affected dashboards")
+    _reconvert_streamline_dashboards()
 
 
 @service

--- a/pyscript/apps/lovelace_to_yaml/lovelace_core.py
+++ b/pyscript/apps/lovelace_to_yaml/lovelace_core.py
@@ -52,6 +52,45 @@ def get_lovelace_id_from_url(url: str | None, storage_dir: str) -> str:
     return match["id"]
 
 
+def list_dashboard_urls(storage_dir: str) -> list:
+    """Return all dashboard url_paths from the registry, plus None for the default.
+
+    None represents the default dashboard (fixed storage ID "lovelace"), which
+    is always present but has no registry entry.  Registered dashboards follow.
+
+    If the registry file is missing or malformed, returns [None] so callers
+    still process the default dashboard.
+    """
+    urls = [None]
+    try:
+        registry_path = os.path.join(storage_dir, "lovelace_dashboards")
+        with open(registry_path, encoding="utf-8") as f:
+            data = json.load(f)
+        for item in data["data"]["items"]:
+            urls.append(item["url_path"])
+    except Exception:
+        pass
+    return urls
+
+
+def dashboard_uses_streamline(url, storage_dir: str) -> bool:
+    """Return True if the dashboard's storage file references custom:streamline-card.
+
+    Uses a raw string search rather than JSON parsing — the type identifier is
+    distinctive enough that false positives are not possible in HA storage JSON
+    (no comments, entity IDs use dots not colons).
+
+    Returns False on any error (unknown url_path, missing storage file, etc.).
+    """
+    try:
+        dashboard_id = get_lovelace_id_from_url(url, storage_dir)
+        storage_path = os.path.join(storage_dir, f"lovelace.{dashboard_id}")
+        with open(storage_path, encoding="utf-8") as f:
+            return "custom:streamline-card" in f.read()
+    except Exception:
+        return False
+
+
 def extract_dashboard_config(json_data: dict) -> dict:
     """Extract the dashboard config from a HA .storage file envelope."""
     return json_data["data"]["config"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def config_dir(tmp_path):
     """Temporary HA config directory pre-populated with fixture storage files."""
     storage = tmp_path / ".storage"
     storage.mkdir()
-    for name in ["lovelace_dashboards", "lovelace.map", "lovelace.lovelace"]:
+    for name in ["lovelace_dashboards", "lovelace.map", "lovelace.lovelace", "lovelace.streamline_dash"]:
         src = os.path.join(FIXTURES_DIR, f"{name}.json")
         (storage / name).write_text(
             open(src, encoding="utf-8").read(), encoding="utf-8"

--- a/tests/fixtures/lovelace.streamline_dash.json
+++ b/tests/fixtures/lovelace.streamline_dash.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "lovelace.streamline_dash",
+  "data": {
+    "config": {
+      "views": [
+        {
+          "title": "Streamline Test",
+          "cards": [
+            {
+              "type": "custom:streamline-card",
+              "template": "btn",
+              "variables": {"entity": "light.kitchen"}
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/lovelace_dashboards.json
+++ b/tests/fixtures/lovelace_dashboards.json
@@ -20,6 +20,14 @@
         "mode": "storage",
         "require_admin": false,
         "show_in_sidebar": true
+      },
+      {
+        "id": "streamline_dash",
+        "title": "Streamline Test",
+        "url_path": "streamline-dash",
+        "mode": "storage",
+        "require_admin": false,
+        "show_in_sidebar": true
       }
     ]
   }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,9 +18,11 @@ from lovelace_core import (
     _substitute_variables,
     convert_dashboard,
     convert_to_yaml,
+    dashboard_uses_streamline,
     expand_streamline_cards,
     extract_dashboard_config,
     get_lovelace_id_from_url,
+    list_dashboard_urls,
     load_streamline_templates,
 )
 
@@ -50,6 +52,66 @@ def test_get_id_missing_registry_raises(tmp_path):
     """A missing registry file should raise FileNotFoundError."""
     with pytest.raises(FileNotFoundError):
         get_lovelace_id_from_url("map", str(tmp_path))
+
+
+# ── list_dashboard_urls ───────────────────────────────────────────────────────
+
+def test_list_dashboard_urls_includes_default_and_registered(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    urls = list_dashboard_urls(storage_dir)
+    assert None in urls
+    assert "map" in urls
+    assert "office-panel" in urls
+    assert "streamline-dash" in urls
+
+
+def test_list_dashboard_urls_default_is_first(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    urls = list_dashboard_urls(storage_dir)
+    assert urls[0] is None
+
+
+def test_list_dashboard_urls_missing_registry_returns_default_only(tmp_path):
+    urls = list_dashboard_urls(str(tmp_path))
+    assert urls == [None]
+
+
+def test_list_dashboard_urls_empty_registry(tmp_path):
+    storage = tmp_path / ".storage"
+    storage.mkdir()
+    (storage / "lovelace_dashboards").write_text(
+        '{"version":1,"minor_version":1,"key":"lovelace_dashboards","data":{"items":[]}}',
+        encoding="utf-8",
+    )
+    urls = list_dashboard_urls(str(storage))
+    assert urls == [None]
+
+
+# ── dashboard_uses_streamline ─────────────────────────────────────────────────
+
+def test_dashboard_uses_streamline_true_for_streamline_dashboard(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    assert dashboard_uses_streamline("streamline-dash", storage_dir) is True
+
+
+def test_dashboard_uses_streamline_false_for_plain_dashboard(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    assert dashboard_uses_streamline("map", storage_dir) is False
+
+
+def test_dashboard_uses_streamline_false_for_default_dashboard(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    assert dashboard_uses_streamline(None, storage_dir) is False
+
+
+def test_dashboard_uses_streamline_false_for_missing_storage_file(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    assert dashboard_uses_streamline("office-panel", storage_dir) is False
+
+
+def test_dashboard_uses_streamline_false_for_unknown_url(config_dir):
+    storage_dir = os.path.join(config_dir, ".storage")
+    assert dashboard_uses_streamline("no-such-dashboard", storage_dir) is False
 
 
 # ── extract_dashboard_config ──────────────────────────────────────────────────

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -148,3 +148,79 @@ def test_service_with_none_converts_default(pyscript_app, output_dir):
     mod, _ = pyscript_app
     mod.lovelace_convert(url=None)
     assert os.path.exists(os.path.join(output_dir, "lovelace_lovelace.yaml"))
+
+
+# ── E. streamline_templates_changed (folder_watcher handler) ─────────────────
+
+
+def test_folder_watcher_event_trigger_registered(pyscript_app):
+    """@event_trigger must record 'folder_watcher' on the handler."""
+    mod, _ = pyscript_app
+    assert hasattr(mod.streamline_templates_changed, "_event_trigger")
+    assert mod.streamline_templates_changed._event_trigger == "folder_watcher"
+
+
+def test_folder_watcher_converts_streamline_dashboards(pyscript_app, output_dir):
+    """Matching event must reconvert dashboards that use custom:streamline-card."""
+    mod, _ = pyscript_app
+    mod.streamline_templates_changed(
+        path="/config/www/community/streamline-card/streamline_templates.yaml",
+        event_type="modified",
+    )
+    assert os.path.exists(os.path.join(output_dir, "lovelace_streamline_dash.yaml"))
+
+
+def test_folder_watcher_does_not_convert_plain_dashboards(pyscript_app, output_dir):
+    """Reconvert must skip dashboards with no custom:streamline-card reference."""
+    mod, _ = pyscript_app
+    mod.streamline_templates_changed(
+        path="/config/www/community/streamline-card/streamline_templates.yaml",
+        event_type="modified",
+    )
+    assert not os.path.exists(os.path.join(output_dir, "lovelace_map.yaml"))
+    assert not os.path.exists(os.path.join(output_dir, "lovelace_lovelace.yaml"))
+
+
+def test_folder_watcher_ignores_unrelated_files(pyscript_app, output_dir):
+    """Events for other files must not trigger reconversion."""
+    mod, _ = pyscript_app
+    mod.streamline_templates_changed(path="/config/some_other_file.yaml", event_type="modified")
+    assert not any(os.listdir(output_dir))
+
+
+def test_folder_watcher_ignores_deleted_event(pyscript_app, output_dir):
+    """'deleted' event_type must not trigger reconversion."""
+    mod, _ = pyscript_app
+    mod.streamline_templates_changed(
+        path="/config/www/community/streamline-card/streamline_templates.yaml",
+        event_type="deleted",
+    )
+    assert not any(os.listdir(output_dir))
+
+
+def test_folder_watcher_handles_closed_event(pyscript_app, output_dir):
+    """'closed' event_type (vim-style save) must trigger reconversion."""
+    mod, _ = pyscript_app
+    mod.streamline_templates_changed(
+        path="/config/www/community/streamline-card/streamline_templates.yaml",
+        event_type="closed",
+    )
+    assert os.path.exists(os.path.join(output_dir, "lovelace_streamline_dash.yaml"))
+
+
+def test_folder_watcher_logs_via_pyscript_log(pyscript_app):
+    """streamline_templates_changed must call log.info (pyscript global)."""
+    mod, log_proxy = pyscript_app
+    mod.streamline_templates_changed(
+        path="/config/www/community/streamline-card/streamline_templates.yaml",
+        event_type="modified",
+    )
+    assert any("streamline_templates.yaml" in msg for msg in log_proxy.messages("info"))
+
+
+def test_reconvert_uses_stdlib_logging_not_pyscript_log(pyscript_app):
+    """_reconvert_streamline_dashboards must use _LOGGER, not log."""
+    src = inspect.getsource(pyscript_app[0]._reconvert_streamline_dashboards)
+    assert "_LOGGER" in src
+    assert "log.info" not in src
+    assert "log.error" not in src


### PR DESCRIPTION
## Summary

- Adds `list_dashboard_urls()` and `dashboard_uses_streamline()` to `lovelace_core.py`
- Adds `_reconvert_streamline_dashboards()` executor and `streamline_templates_changed` `folder_watcher` event handler to `__init__.py`
- When `streamline_templates.yaml` is manually edited, only dashboards referencing `custom:streamline-card` are reconverted — plain dashboards are skipped
- Documents required `folder_watcher` HA config in README

## Test plan

- [x] 80 tests, all passing (`pytest -v`)
- [x] Unit tests for `list_dashboard_urls` and `dashboard_uses_streamline`
- [x] Integration tests for `folder_watcher` event handler (correct file, wrong file, deleted event, closed event, logging)